### PR TITLE
Fix dark mode article title visibility on hover

### DIFF
--- a/components/blog-card.tsx
+++ b/components/blog-card.tsx
@@ -19,7 +19,7 @@ interface BlogCardProps {
 export default function BlogCard({ post }: BlogCardProps) {
   return (
     <Link href={`/a/${post.slug}`} className="group h-full">
-      <article className="flex flex-col h-full bg-white shadow-lg overflow-hidden transition-all duration-300 hover:shadow-2xl hover:-translate-y-2 border border-gradient-to-r from-[#228B22]/10 to-[#FFBF00]/10 relative rounded-lg">
+      <article className="flex flex-col h-full bg-white dark:bg-gray-800 shadow-lg overflow-hidden transition-all duration-300 hover:shadow-2xl hover:-translate-y-2 border border-gradient-to-r from-[#228B22]/10 to-[#FFBF00]/10 relative rounded-lg">
 
         {post.featured && (
           <div className="absolute top-3 right-3 z-20">
@@ -44,13 +44,13 @@ export default function BlogCard({ post }: BlogCardProps) {
         </div>
 
         <div className="flex flex-col flex-grow p-6">
-          <h2 className="text-xl font-bold text-gray-900 mb-3 line-clamp-2 group-hover:bg-gradient-to-r group-hover:from-[#228B22] group-hover:to-[#91A511] group-hover:bg-clip-text group-hover:text-transparent transition-all duration-300">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-3 line-clamp-2 group-hover:bg-gradient-to-r group-hover:from-[#228B22] group-hover:to-[#91A511] group-hover:bg-clip-text group-hover:text-transparent transition-all duration-300">
             {post.title}
           </h2>
 
-          <p className="text-gray-600 mb-4 line-clamp-3">{post.excerpt}</p>
+          <p className="text-gray-600 dark:text-gray-300 mb-4 line-clamp-3">{post.excerpt}</p>
 
-          <div className="mt-auto flex items-center justify-between text-sm text-gray-500">
+          <div className="mt-auto flex items-center justify-between text-sm text-gray-500 dark:text-gray-400">
             <div className="flex items-center gap-1 group-hover:text-[#228B22] transition-colors">
               <User className="w-4 h-4" />
               <span>{post.author}</span>


### PR DESCRIPTION
## Problem
Article titles become invisible when hovering over article cards in dark mode due to the gradient effect applying `text-transparent` without proper contrast against the dark background.

## Solution
Added comprehensive dark mode styling to `blog-card.tsx`:
- **Card background**: `dark:bg-gray-800` - provides proper dark background
- **Title text**: `dark:text-gray-100` - ensures visibility before hover
- **Excerpt text**: `dark:text-gray-300` - maintains readability
- **Metadata text**: `dark:text-gray-400` - appropriate contrast for author info

## Result
✅ Article titles now remain visible in dark mode
✅ Green gradient hover effect works correctly on both light and dark backgrounds
✅ Improved user experience for dark mode users

## Testing
Tested locally with dark mode enabled - titles are now clearly visible and the hover gradient effect displays properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added complete dark mode styling support to blog cards. Visual enhancements include darker background colors paired with optimized text colors for article titles, excerpts, and author metadata information. These updates improve readability and ensure a consistent appearance when users switch between light and dark display modes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->