### PR TITLE
feat: compact header and add GitHub icon  #57 

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import BlogCard from "@/components/blog-card"
 import Pagination from "@/components/pagination"
 import Link from "next/link"
 import Footer from "@/components/footer"
+import { Github } from "lucide-react"
 
 interface BlogPost {
   slug: string
@@ -101,19 +102,29 @@ export default function HomePage() {
     <div className="min-h-screen bg-gradient-to-br from-green-50 via-yellow-50 to-[#FFC517]/10">
       {/* Header */}
       <header className="border-b border-gradient-to-r from-[#228B22]/20 to-[#FFBF00]/20 bg-white/90 backdrop-blur-sm sticky top-0 z-50 shadow-sm">
-        <div className="max-w-6xl mx-auto px-4 py-6 flex justify-between items-center">
+        <div className="max-w-6xl mx-auto px-4 py-3 flex justify-between items-center">
           <div>
-            <h1 className="text-5xl font-bold font-playfair bg-gradient-to-r from-[#228B22] via-[#5A981A] via-[#91A511] via-[#ADAC0D] via-[#E4B905] to-[#FFBF00] bg-clip-text text-transparent drop-shadow-sm leading-tight pb-2">
+            <h1 className="text-2xl font-bold font-playfair bg-gradient-to-r from-[#228B22] via-[#5A981A] via-[#91A511] via-[#ADAC0D] via-[#E4B905] to-[#FFBF00] bg-clip-text text-transparent drop-shadow-sm leading-tight">
               Stable Viewpoints
             </h1>
-            <p className="text-gray-600 mt-2 text-lg">Independent Articles about Stability</p>
+            <p className="text-gray-600 text-sm">Independent Articles about Stability</p>
           </div>
-          <Link
-            href="/submit"
-            className="inline-flex items-center gap-2 bg-gradient-to-r from-[#228B22] to-[#91A511] hover:from-[#3E921E] hover:to-[#ADAC0D] text-white px-6 py-3 font-semibold transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5"
-          >
-            Submit an Article
-          </Link>
+          <div className="flex items-center gap-6">
+            <a
+              href="https://github.com/StabilityNexus/StableViewpoints"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-black text-white p-2 rounded-full hover:bg-gray-800 transition-colors"
+            >
+              <Github className="w-5 h-5" />
+            </a>
+            <Link
+              href="/submit"
+              className="inline-flex items-center gap-2 bg-gradient-to-r from-[#228B22] to-[#91A511] hover:from-[#3E921E] hover:to-[#ADAC0D] text-white px-4 py-2 text-sm font-semibold transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5"
+            >
+              Submit an Article
+            </Link>
+          </div>
         </div>
       </header>
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/8001618d-7ccd-4eb7-bcf7-e12495360046

there is proof of and before is like  
<img width="1919" height="308" alt="image" src="https://github.com/user-attachments/assets/093d5823-4740-45b6-b1f3-2f401ab41817" />


so its a better choice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style & UI Improvements**
  * Redesigned header layout with improved visual hierarchy.
  * Added GitHub link button in the header for easier access.
  * Integrated "Submit an Article" link into the header for better navigation accessibility.
  * Reduced header spacing for a more compact appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->